### PR TITLE
Added step to build on windows in the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Clone the repo somewhere and cd into it. Then:<br/>
 <pre>
 composer install
 npm install --global gulp-cli
+npm install --global --production windows-build-tools (On Windows Only)
 npm shrinkwrap
 npm install
 cp .env-example .env


### PR DESCRIPTION
To restore the npm dependencies on windows using npm v6.++ and build the project we need phyton2 and visualC++ compiler, otherwise the npm install will fail. Added the command to solve this issue in the build instructions.